### PR TITLE
feat: Added the ability to optionally change Ripple color, speed, opacity and transition type

### DIFF
--- a/src/Ripple.tsx
+++ b/src/Ripple.tsx
@@ -10,11 +10,21 @@ import {
 } from 'react'
 import styles from './Ripple.module.css'
 
-export type RippleProps = Record<string, never>
-
 const interactiveElementSelector = 'a, button' as const
 
-export const Ripple: FunctionComponent<RippleProps> = () => {
+type RipplesStyleProps = {
+	rippleOpacity?: number
+	transition?: string
+	rippleSpeed?: string
+	rippleColor?: string
+}
+
+export const Ripple: FunctionComponent<RipplesStyleProps> = ({
+	rippleOpacity = 0.2,
+	transition = 'ease in',
+	rippleSpeed = '0.6s',
+	rippleColor = 'currentcolor',
+}) => {
 	const [ripples, setRipples] = useState<
 		Array<{
 			id: number
@@ -88,6 +98,10 @@ export const Ripple: FunctionComponent<RippleProps> = () => {
 					key={ripple.id}
 					style={
 						{
+							'--Ripple-opacity': rippleOpacity,
+							animationDuration: rippleSpeed,
+							animationTimingFunction: transition,
+							backgroundColor: rippleColor,
 							'--Ripple-size': `${ripple.size}px`,
 							'--Ripple-x': `${ripple.x}px`,
 							'--Ripple-y': `${ripple.y}px`,


### PR DESCRIPTION
So I came upon your Ripple effect package and used it in my project because it is actually the only that worked for me :) (it was very helpful).

I just wanted to extend its functionalities and added those features + it is typed; here is an example:
`
<Ripple rippleSpeed="500ms" rippleColor="red" rippleOpacity={0.8} transition="ease-in-out" />
`
[Example in video](https://github.com/FilipChalupa/react-ripple-click/assets/137171976/1c30d78c-4d3f-4c26-9cb3-745aec28d5bc)

Hope you like it :)